### PR TITLE
Removal of admin_consent prompt

### DIFF
--- a/Test-IntuneFirewallRules.ps1
+++ b/Test-IntuneFirewallRules.ps1
@@ -374,7 +374,7 @@ function Get-AuthToken {
     
     $userId = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier" -ArgumentList ($User, "OptionalDisplayableId")
     
-    $authResult = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, $platformParameters, $userId, "prompt=admin_consent").Result
+    $authResult = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, $platformParameters, $userId).Result
     
     if ($authResult.AccessToken) {
     


### PR DESCRIPTION
This isn't need for every script as it will prompt for permissions every time you run it